### PR TITLE
Update C11&12 coordinates

### DIFF
--- a/content/pages/k2-observing/k2-campaign-fields.md
+++ b/content/pages/k2-observing/k2-campaign-fields.md
@@ -159,8 +159,8 @@ by K2.
       <td>2016 Sep 27</td>
       <td>2016 Dec 16</td>
       <td>2017 Mar 19</td>
-      <td>17:19:53.12</td>
-      <td>-23:56:57.07</td>
+      <td>17:21:33.12</td>
+      <td>-23:58:33.45</td>
       <td></td>
       <td>Galactic Center</td>
       </tr>
@@ -170,8 +170,8 @@ by K2.
       <td>2016 Dec 22</td>
       <td>2017 Mar 12</td>
       <td>2017 Jun 05</td>
-      <td>23:19:12.83</td>
-      <td>-05:52:32.08</td>
+      <td>23:26:42.61</td>
+      <td>-5:05:44.33</td>
       <td></td>
       <td>South Galactic Cap</td>
     </tr>

--- a/content/pages/k2-observing/k2-campaign-fields.md
+++ b/content/pages/k2-observing/k2-campaign-fields.md
@@ -171,7 +171,7 @@ by K2.
       <td>2017 Mar 12</td>
       <td>2017 Jun 05</td>
       <td>23:26:42.61</td>
-      <td>-5:05:44.33</td>
+      <td>-05:05:44.33</td>
       <td></td>
       <td>South Galactic Cap</td>
     </tr>
@@ -185,7 +185,7 @@ by K2.
 
 <div class="panel panel-primary">
   <div class="panel-heading">
-    <h3 class="panel-title">Proposed future fields</h3>
+    <h3 class="panel-title">Proposed future fields (coordinates may change)</h3>
   </div>
   <div class="panel-body">
 


### PR DESCRIPTION
The new website does not yet list the final positions for C11 & C12.  Using the coordinates listed at the top of KACR-1751 and KACR-1752, I find the following positions for C11 and C12 (respectively) in sexagesimal:

```Python
In [16]: from astropy.coordinates import SkyCoord
In [17]: SkyCoord(260.3880071 , -23.9759578, unit="deg", frame="icrs").to_string(style="hmsdms")
Out[17]: '17h21m33.1217s -23d58m33.4481s'
In [18]: SkyCoord(351.6775368, -5.095648, unit="deg", frame="icrs").to_string(style="hmsdms")
Out[18]: '23h26m42.6088s -05d05m44.3328s'
```

The attached pull request updates the campaign fields page. @mrtommyb please review (given how important this is) and merge.

I'll open a separate issue to remind us to update C13 when it is fixed.

I'll open another ticket reminding us to remove any outdated coordinates from the old website.