### PR TITLE
Fix Number of C15 SC Standard Targets

### DIFF
--- a/content/pages/k2-observing/k2-approved-programs.rst
+++ b/content/pages/k2-observing/k2-approved-programs.rst
@@ -442,7 +442,7 @@ Campaign 15
 
     <p>
         The Campaign 15 target list includes <b>23,279 standard long cadence</b>
-        and <b>119 standard short cadence</b> targets
+        and <b>118 standard short cadence</b> targets
         located towards the constellations of Scorpius.
     </p>
 


### PR DESCRIPTION
Based on the K2Campaign15targets.csv file, I count 118 standard SC targets, but the webpage (https://keplerscience.arc.nasa.gov/k2-approved-programs.html#campaign-15) says 119

awk 'BEGIN{FS=","} {if($1>201000000) print($0)}' K2Campaign15targets.csv | grep SC | wc

> 118

Opening pull request and requesting review from Geert to see if I am missing one standard SC target somewhere, or if GOOD concurs with update.

(Note running counting code above on campaigns 17, 16, & 14 yields results consistent with webpage doc for those campaigns.)